### PR TITLE
add hyperx as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.1",
   "description": "allows to define custom elements for hyperx, defaulting to your h function of choice",
   "main": "index.js",
-  "license": "BSD"
+  "license": "BSD",
+  "dependencies": {
+    "hyperx": "^2.3.0"
+  }
 }


### PR DESCRIPTION
adds `hyperx` as a dependency, so build systems won't fail when the project doesn't already require it